### PR TITLE
Added (temporary) bug fix for tornado.web.send_error

### DIFF
--- a/charon/api.py
+++ b/charon/api.py
@@ -147,7 +147,6 @@ class ApiNotify(ApiRequestHandler):
             self.send_error(400, reason=str(msg))
         else:
             self.set_status(202)
-            self.finish()
             try:
                 headers = {'X-Userman-API-token': settings['AUTH']['API_TOKEN']}
                 data = dict(service='Charon')

--- a/charon/application.py
+++ b/charon/application.py
@@ -6,7 +6,6 @@ import tornado
 import tornado.web
 import couchdb
 
-import charon
 from charon import constants
 from charon import utils
 from charon import uimodules

--- a/charon/project.py
+++ b/charon/project.py
@@ -183,14 +183,17 @@ class ApiProject(ApiRequestHandler):
         try:
             data = json.loads(self.request.body)
         except Exception, msg:
+            logging.debug("Exception: %s", msg)
             self.send_error(400, reason=str(msg))
         else:
             try:
                 with self.saver(doc=project, rqh=self) as saver:
                     saver.store(data=data)
             except ValueError, msg:
+                logging.debug("ValueError: %s", msg)
                 self.send_error(400, reason=str(msg))
             except IOError, msg:
+                logging.debug("IOError: %s", msg)
                 self.send_error(409, reason=str(msg))
             else:
                 self.set_status(204)

--- a/charon/saver.py
+++ b/charon/saver.py
@@ -30,7 +30,7 @@ class Field(object):
         try:
             value = self.process(saver, value)
         except ValueError, msg:
-            raise ValueError("field {0}: {1}".format(self.key, msg))
+            raise ValueError("field '{0}': {1}".format(self.key, msg))
         if value == saver.doc.get(self.key):
             logging.debug("Field.store: '%s' value equal", self.key)
             return

--- a/charon/test_project.py
+++ b/charon/test_project.py
@@ -27,6 +27,7 @@ def test_project_create_not_json():
                             data='% not JSON',
                             headers=api_token)
     assert response.status_code == 400, response
+    assert response.reason == 'No JSON object could be decoded'
 
 def test_project_create():
     "Create a project."
@@ -112,6 +113,7 @@ def test_project_modify_status_field():
                            data=json.dumps(data),
                            headers=api_token)
     assert response.status_code == 400, response
+    assert response.reason == "field 'status': invalid value; not among options for select"
 
 def test_project_delete():
     "Delete a project."


### PR DESCRIPTION
Added the **send_error** method from tornado.web.RequestHandler, _with_ a bug fix, so that the custom-made reason phrase describing the problem actually gets through.

I think this is a bug in Tornado, and I have also sent a pull request of the corrected code to the Tornado master repo.
