### PR TITLE
Handle connection issues differently

### DIFF
--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -1,4 +1,3 @@
-
 import argparse
 import copy
 import json
@@ -234,10 +233,14 @@ class CharonDocumentTracker:
             doc['analysis_status'] = 'TO_ANALYZE'
 
             # doc will not be updated if there is a connection error. Script will continue with the next sample
-            remote_sample=self.get_charon_sample(sample.name)
-            if remote_sample and remote_sample.get('status') == 'STALE' and self.seqruns_for_sample(sample.name) == self.remote_seqruns_for_sample(sample.name):
-                doc['status'] = 'STALE'
-            elif remote_sample is None:
+            try:
+                remote_sample = self.get_charon_sample(sample.name)
+                seqruns_lims = self.seqruns_for_sample(sample.name)
+                seqruns_charon = self.remote_seqruns_for_sample(sample.name)
+                if remote_sample and remote_sample.get('status') == 'STALE' and seqruns_lims == seqruns_charon:
+                    doc['status'] = 'STALE'
+            except Exception as e:
+                self.logger.error("An error occurred while updating {}: {}. Skipping it.".format(sample.name, e))
                 continue
 
             for udf in sample.udfs:
@@ -338,8 +341,11 @@ class CharonDocumentTracker:
         if r.status_code == requests.codes.ok:
             for sr in r.json()['seqruns']:
                 seqruns.add(sr['seqrunid'])
-
-        return seqruns
+            return seqruns
+        elif r.status_code == requests.codes.not_found:
+            return None
+        else:
+            raise Exception('An unknown connection error occurred while getting the seqrun from Charon')
 
     def get_charon_sample(self, sampleid):
         session = requests.Session()
@@ -348,8 +354,10 @@ class CharonDocumentTracker:
         r = session.get(url, headers=headers)
         if r.status_code == requests.codes.ok:
             return r.json()
-        else:
+        elif r.status_code == requests.codes.not_found:
             return None
+        else:
+            raise Exception('An unknown connection error occurred while getting the sample from Charon')
 
     def update_charon(self):
         session = requests.Session()

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -345,7 +345,7 @@ class CharonDocumentTracker:
         elif r.status_code == requests.codes.not_found:
             return None
         else:
-            raise Exception('An unknown connection error occurred while getting the seqrun from Charon')
+            raise Exception('A connection error "{}" occurred while getting the seqrun from Charon'.format(r.status_code))
 
     def get_charon_sample(self, sampleid):
         session = requests.Session()
@@ -357,7 +357,7 @@ class CharonDocumentTracker:
         elif r.status_code == requests.codes.not_found:
             return None
         else:
-            raise Exception('An unknown connection error occurred while getting the sample from Charon')
+            raise Exception('A connection error "{}" occurred while getting the sample from Charon'.format(r.status_code))
 
     def update_charon(self):
         session = requests.Session()


### PR DESCRIPTION
We want to skip updating the sample doc if there is a connection error to Charon when fetching the sample data, but if the request status is 404 we still want to generate a doc and try to add the sample to Charon. To fix this:

* Have `get_charon_sample` and `remote_seqruns_for_sample` raise an exception if the request status is not 200 or 404
* Make `generate_samples_docs` catch the exception and skip the affected sample