### PR TITLE
Refactor acheron_sql to create doc stubs for comparison before actual doc generation

### DIFF
--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -346,27 +346,6 @@ class CharonDocumentTracker:
                 fields['Type'] = udf.udfvalue
         return fields
 
-    def remove_duplicate_libs(self, libs):
-        samples_lists=[]
-        libs.sort(reverse=True, key=lambda x:(x.daterun or datetime.now()))
-        for lib in libs:
-            query = "select sa.* from sample sa inner join \
-            artifact_sample_map asm on sa.processid = asm.processid inner join \
-            processiotracker piot on asm.artifactid = piot.inputartifactid \
-            where piot.processid = {libid}".format(libid = lib.processid)
-            samples = self.session.query(Sample).from_statement(text(query)).all()
-            samples_lists.append(samples)
-        duplicate_libs_ids=set()
-        for i in range(0, len(libs)):
-            for j in range(i+1, len(libs)):
-                if set(samples_lists[i]) == set(samples_lists[j]):
-                    duplicate_libs_ids.add(j)
-
-        for idx in sorted(list(duplicate_libs_ids), reverse = True):
-            del libs[idx]
-
-        return libs
-
     def generate_new_libprep_doc(self):
         curtime = datetime.now().isoformat()
         fields = {}

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -96,7 +96,7 @@ def merge(d1, d2):
 
 def is_modified(keys, dict1, dict2):
     for key in keys:
-        if dict1.get(key) != str(dict2.get(key)):
+        if dict1.get(key) != dict2.get(key):
             return True
     return False
 
@@ -248,9 +248,9 @@ class CharonDocumentTracker:
     def generate_samples_libprep_seqrun_docs_stub(self):
         for sample in self.project.samples:
             sample_doc = {}
-            doc['charon_doctype'] = 'sample'
-            doc['projectid'] = self.project.luid
-            doc['sampleid'] = sample.name
+            sample_doc['charon_doctype'] = 'sample'
+            sample_doc['projectid'] = self.project.luid
+            sample_doc['sampleid'] = sample.name
             self.samples[sample.name] = sample
             self.docs.append(sample_doc)
 
@@ -263,10 +263,10 @@ class CharonDocumentTracker:
             alphaindex = 65
             for lib in libs:
                 lib_doc = {}
-                doc['charon_doctype'] = 'libprep'
-                doc['projectid'] = self.project.luid
-                doc['sampleid'] = sample.name
-                doc['libprepid'] = chr(alphaindex)
+                lib_doc['charon_doctype'] = 'libprep'
+                lib_doc['projectid'] = self.project.luid
+                lib_doc['sampleid'] = sample.name
+                lib_doc['libprepid'] = chr(alphaindex)
                 self.docs.append(lib_doc)
 
                 query = "select distinct pro.* from process pro \
@@ -281,7 +281,7 @@ class CharonDocumentTracker:
                     seqdoc['sampleid'] = sample.name
                     seqdoc['libprepid'] = chr(alphaindex)
                     for udf in seq.udfs:
-                        if udf.udfname == "Run ID":
+                        if udf.udfname == "Run ID" and udf.udfvalue:
                             seqdoc['seqrunid'] = udf.udfvalue
                             break
                     if 'seqrunid' in seqdoc:
@@ -316,9 +316,9 @@ class CharonDocumentTracker:
             if udf.udfname == 'Status (manual)':
                 if udf.udfvalue == 'Aborted':
                     fields['status'] = 'ABORTED'
-            if udf.udfname == 'Sample Links':
+            if udf.udfname == 'Sample Links' and udf.udfvalue:
                 fields['Pair'] = udf.udfvalue
-            if udf.udfname == 'Sample Link Type':
+            if udf.udfname == 'Sample Link Type' and udf.udfvalue:
                 fields['Type'] = udf.udfvalue
         return fields
 
@@ -340,9 +340,9 @@ class CharonDocumentTracker:
             if udf.udfname == 'Status (manual)':
                 if udf.udfvalue == 'Aborted':
                     fields['status'] = 'ABORTED'
-            if udf.udfname == 'Sample Links':
+            if udf.udfname == 'Sample Links' and udf.udfvalue:
                 fields['Pair'] = udf.udfvalue
-            if udf.udfname == 'Sample Link Type':
+            if udf.udfname == 'Sample Link Type' and udf.udfvalue:
                 fields['Type'] = udf.udfvalue
         return fields
 

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -198,10 +198,11 @@ class CharonDocumentTracker:
         
         for udf in self.project.udfs:
             if udf.udfname == 'Bioinformatic QC':
-                if udf.udfvalue == 'WG re-seq':
-                    doc['best_practice_analysis'] = 'whole_genome_reseq'
-                else:
-                    doc['best_practice_analysis'] = udf.udfvalue
+                if udf.udfvalue:
+                    if udf.udfvalue == 'WG re-seq':
+                        doc['best_practice_analysis'] = 'whole_genome_reseq'
+                    else:
+                        doc['best_practice_analysis'] = udf.udfvalue
             if udf.udfname == 'Uppnex ID' and udf.udfvalue:
                 doc['uppnex_id'] = udf.udfvalue.strip()
             if udf.udfname == 'Reference genome' and udf.udfvalue:
@@ -385,7 +386,7 @@ class CharonDocumentTracker:
         for doc in self.docs:
             try:
                 if doc['charon_doctype'] == 'project':
-                    self.logger.info(f"trying to update doc {doc['projectid']}")
+                    self.logger.info(f"checking for updates to doc {doc['projectid']}")
                     #Check if the project exists in Charon
                     url = f"{self.charon_url}/api/v1/project/{doc['projectid']}"
                     r = session.get(url, headers=headers)
@@ -409,7 +410,7 @@ class CharonDocumentTracker:
                     #If the sample doc does not exist, create it by adding the fields required for new documents to the stub
                     if r.status_code == 404:
                         url = "{0}/api/v1/sample/{1}".format(self.charon_url, doc['projectid'])
-                        doc.update(self.add_new_samples_doc_fields()
+                        doc.update(self.add_new_samples_doc_fields())
                         rq = session.post(url, headers=headers, data=json.dumps(doc))
                         if rq.status_code == requests.codes.created:
                             self.logger.info(f"sample {doc['projectid']}/{doc['sampleid']} successfully updated")

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -358,7 +358,7 @@ class CharonDocumentTracker:
                 This is not a general function to compare two dicts.
                 """
             for key in dict2.keys():
-                if dict1.get(key, 'unlikely default value') != dict2.get(key):
+                if key not in dict1 or dict1[key] != dict2[key]:
                     return True
             return False
 

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -94,11 +94,6 @@ def merge(d1, d2):
             d3[key] = d2[key]
     return d3
 
-def are_dicts_different(keys, dict1, dict2):
-    for key in keys:
-        if dict1.get(key) != dict2.get(key):
-            return True
-    return False
 
 def masterProcess(args, projectList, logger):
     projectsQueue = mp.JoinableQueue()
@@ -358,8 +353,18 @@ class CharonDocumentTracker:
         """Check if new_doc stub document has any changes recorded in the LIMS compared to cur_doc (fetched from charon api). 
         Only need to compare the keys present in the stub. If changes are detected, the document in charon is modified.
         """
-        keys_to_check = new_doc.keys()
-        if are_dicts_different(keys_to_check, cur_doc, new_doc):
+
+        def are_keyvalues_in_dict2_different_than_in_dict1(dict1, dict2):
+            """Check if the values of the keys in the dict2 are present in the dict1.
+                If not, return True. If the values are the same, return False.
+                This is not a general function to compare two dicts.
+                """
+            for key in dict2.keys():
+                if dict1.get(key, 'unlikely default value') != dict2.get(key):
+                    return True
+            return False
+
+        if are_keyvalues_in_dict2_different_than_in_dict1(cur_doc, new_doc):
             merged = merge(cur_doc, new_doc)
             if merged != cur_doc:
                 curtime = datetime.now().isoformat()

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -355,6 +355,9 @@ class CharonDocumentTracker:
 
 
     def update_charon_modifications(self, cur_doc, new_doc, url, session, headers):
+        """Check if new_doc stub document has any changes recorded in the LIMS compared to cur_doc (fetched from charon api). 
+        Only need to compare the keys present in the stub. If changes are detected, the document in charon is modified.
+        """
         keys_to_check = new_doc.keys()
         if are_dicts_different(keys_to_check, cur_doc, new_doc):
             merged = merge(cur_doc, new_doc)

--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -173,7 +173,6 @@ class CharonDocumentTracker:
         self.session = session
         self.project = project
         self.logger = logger
-        self.samples = {}
         self.docs = []
 
     def run(self):
@@ -232,7 +231,6 @@ class CharonDocumentTracker:
             sample_doc['charon_doctype'] = 'sample'
             sample_doc['projectid'] = self.project.luid
             sample_doc['sampleid'] = sample.name
-            self.samples[sample.name] = sample
             
             try:
                 remote_sample = self.get_charon_sample(sample.name)
@@ -300,7 +298,7 @@ class CharonDocumentTracker:
                 alphaindex += 1
 
 
-    def add_new_samples_doc_fields(self, sample_name):
+    def add_new_samples_doc_fields(self):
         fields = {}
         curtime = datetime.now().isoformat()
         fields['created'] = curtime
@@ -411,7 +409,7 @@ class CharonDocumentTracker:
                     #If the sample doc does not exist, create it by adding the fields required for new documents to the stub
                     if r.status_code == 404:
                         url = "{0}/api/v1/sample/{1}".format(self.charon_url, doc['projectid'])
-                        doc.update(self.add_new_samples_doc_fields(doc['sampleid']))
+                        doc.update(self.add_new_samples_doc_fields()
                         rq = session.post(url, headers=headers, data=json.dumps(doc))
                         if rq.status_code == requests.codes.created:
                             self.logger.info(f"sample {doc['projectid']}/{doc['sampleid']} successfully updated")


### PR DESCRIPTION
**Issue**: Acheron was modifying documents for samples, libprep and seqrun for updated projects even if they had no updates.  It was also setting sample status back to 'FRESH' whenever the project had any update.

**Attempted solution**: Break up document updation so that fields required by new documents are added only if the document is not present in Charon. 

Also redundant code for updating libpreps and seqruns was removed since acheron never updated them with fields from LIMS

