### PR TITLE
Declare RegEx pattern as a raw string

### DIFF
--- a/charon/acheron_sql.py
+++ b/charon/acheron_sql.py
@@ -17,7 +17,7 @@ from sqlalchemy import text
 from charon.utils import QueueHandler
 
 
-REFERENCE_GENOME_PATTERN = re.compile("\,\s+([0-9A-z\._-]+)\)")
+REFERENCE_GENOME_PATTERN = re.compile(r"\,\s+([0-9A-z\._-]+)\)")
 
 
 def main(args):


### PR DESCRIPTION
To suppress the warning
`/home/ngi.web/src/charon/charon/acheron_sql.py:20: SyntaxWarning: invalid escape sequence '\,'
 REFERENCE_GENOME_PATTERN = re.compile("\,\s+([0-9A-z\._-]+)\)")`